### PR TITLE
Force user to fill in missing profile data

### DIFF
--- a/django/bober/bober_simple_competition/forms.py
+++ b/django/bober/bober_simple_competition/forms.py
@@ -110,6 +110,8 @@ class BasicProfileForm(forms.ModelForm):
                 pass
         # add the fields not listed above at the end
         self.fields.update(unordered_fields)
+        for k in ['first_name', 'last_name', 'email']:
+            self.fields[k].required = True
 
     def save(self, *args, **kwargs):
         cleaned_data = self.cleaned_data

--- a/django/bober/bober_simple_competition/templates/bober_simple_competition/profile_form.html
+++ b/django/bober/bober_simple_competition/templates/bober_simple_competition/profile_form.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load crispy_forms_tags %}
 {% load i18n %}
 {% load static %}
 {% block title %}{% trans "Edit user" %}{% endblock %}
@@ -9,65 +10,27 @@
 {{form.media}}
 {% endblock %}
 {% block content %}
-{{ object }} [{{ object.pk }}]
-
-
-<div>
-{% for a in object.attempt_list.all %}
-{{a}}<br/>
-{% endfor %}
+<h1>
+<div class=row>
+		<div class="col-sm">
+			{% trans "Profile for" %} {{ object }} [{{ object.pk }}] 
+		</div>
 </div>
+</h1>
+
+{% if not object.email or not object.first_name or not object.last_name %}
+<div class=row>
+	<div class="col-sm">		
+		<div class="alert alert-danger" role="alert">
+			{% trans "Please fill in required data" %} 
+		</div>
+	</div>
+</div>
+{% endif %}
+
 <form action="" method="post" id="profile_form" class="form_compete_table" autocomplete="off">
 {% csrf_token %}
-<table>
-{{form.as_table}}
-</table>
+{{ form | crispy }}
 <input type="submit" value='{% trans "Submit" %}' class="btn"/>
-
-<br><br>
-{% trans "Codes" %}
-<br>
-<a id="toggle_extended_form_fields1">{% trans "Show codes" %}</a>
-<div id="extended_form_fields1" class="longTextBreak">
-	<div><br>
-		{% trans "Used codes" %}<hr>
-		<ul>
-		{% for c in object.used_codes.all %}
-		<li>{{c}}</li>
-		{% endfor %}
-		</ul>
-	</div>
-	
-	<div><br>
-		{% trans "Received codes" %}<hr>
-		<ul>
-		{% for c in object.received_codes.all %}
-		<li>{{c}}</li>
-		{% endfor %}
-		</ul>
-	</div>
-	
-	<div><br>
-		{% trans "Created codes" %}<hr>
-		<ul>
-		{% for c in object.created_codes.all %}
-		<li>{{c}}</li>
-		{% endfor %}
-		</ul>
-	</div>
-</div>
 </form>
-<script type="text/javascript">
-$('#extended_form_fields1').css('visibility','hidden');
-$('#toggle_extended_form_fields1').click(function(){
-  if ( $('#extended_form_fields1').css('visibility') == 'hidden' ){
-    $('#extended_form_fields1').css('visibility','visible');
-    $('#toggle_extended_form_fields1').text('{% trans "Hide codes" %}');
-  } else {
-    $('#extended_form_fields1').css('visibility','hidden');
-    $('#toggle_extended_form_fields1').text('{% trans "Show codes" %}');
-  }
-});
-
-</script>
 {% endblock %}

--- a/django/bober/bober_simple_competition/views.py
+++ b/django/bober/bober_simple_competition/views.py
@@ -286,6 +286,13 @@ class CompetitionList(ListView):
     model = Competition
     queryset = Competition.objects.filter(public=True).order_by('-promoted', '-start')
 
+    def get(self, *args, **kwargs):
+        if hasattr(self.request, 'profile'):
+            profile = self.request.profile
+            if not profile.user.first_name or not profile.user.last_name or not profile.user.email:
+                return redirect('profile_update', profile.id)
+        return super().get(*args, **kwargs)
+
     def get_context_data(self, **kwargs):
         """
         Separate competitions into three groups:
@@ -609,7 +616,7 @@ def competition_code_create(request, slug, user_type='admin'):
                 choices=allowed_effect_choices,
                 widget=forms.CheckboxSelectMultiple(),
                 required=False, label=_("Code effects"))
-    else: # user_type == 'competitor'
+    else:  # user_type == 'competitor'
         generator = competition.competitor_code_generator
         if not admin_codegen.code_matches(
                 access_code,


### PR DESCRIPTION
Make fields first_name, last_name and email in BasicProfileForm
required so they can not be left blank.

If they are blank the user is redirected to the profile update page
when opening competition list page (default landing page).

Closes #53 .